### PR TITLE
Update names on change

### DIFF
--- a/src/server/auth/uqAuthMiddleware.ts
+++ b/src/server/auth/uqAuthMiddleware.ts
@@ -26,7 +26,8 @@ export const uqAuthMiddleware = async (
         if (user.email === redacted) {
             user.email = kvd.email || redacted;
         }
-        if (user.name === redacted) {
+        // Update the name if it's changed - preferred names can change once every 24hrs
+        if (user.name === redacted || user.name !== kvd.name) {
             user.name = kvd.name || redacted;
         }
         await user.save();


### PR DESCRIPTION
Might close #11.

It appears that Users in the system are never updated; students are able to change their "preferred name" once per day via SInet, so this is not a correct assumption.

This is blocked on ITIG Helpdesk responding to my query about the `X-KVD-Payload` name field - the documentation suggests it should be the preferred name. If zones is working as documented, then the problem falls back to the Queue app, and this is the likely culprit.

This PR will be updated with alternative changes to support preferred names if necessary.